### PR TITLE
Updated Paymentrequest to match specification

### DIFF
--- a/src/PaymentRequest.php
+++ b/src/PaymentRequest.php
@@ -76,6 +76,21 @@ class PaymentRequest
     public $datePaid = '';
 
     /**
+     * @var string
+     */
+    public $errorCode = '';
+
+    /**
+     * @var string
+     */
+    public $errorMessage = '';
+
+    /**
+     * @var string
+     */
+    public $additionalInformation = '';
+
+    /**
      * PaymentRequest constructor.
      * @param string[] $data
      */


### PR DESCRIPTION
Paymentrequest did not return error properties even if payment returned status error. Updated the paymentrequest to match the specification on page 34 https://developer.getswish.se/content/uploads/2018/08/MerchantsAPI_Getswish_180814_v1.92.pdf
